### PR TITLE
Implement MVP: text generation benchmark with LLM-as-Judge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=sk-your-openai-api-key
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key

--- a/agentbench/__init__.py
+++ b/agentbench/__init__.py
@@ -1,0 +1,1 @@
+"""AgentBench - AI Agent evaluation platform."""

--- a/agentbench/config.py
+++ b/agentbench/config.py
@@ -1,0 +1,47 @@
+"""Configuration management — environment variables and model registry."""
+
+import os
+
+from dotenv import load_dotenv
+
+from agentbench.models.anthropic_model import AnthropicModel
+from agentbench.models.base import BaseModel
+from agentbench.models.openai_model import OpenAIModel
+
+load_dotenv()
+
+# Model registry: short name -> factory function
+MODEL_REGISTRY: dict[str, type[BaseModel]] = {
+    "openai": OpenAIModel,
+    "anthropic": AnthropicModel,
+}
+
+
+def get_model(name: str) -> BaseModel:
+    """Create a model instance by short name.
+
+    Args:
+        name: One of 'openai', 'anthropic'.
+
+    Returns:
+        A configured model instance.
+    """
+    name = name.strip().lower()
+    if name not in MODEL_REGISTRY:
+        raise ValueError(f"Unknown model: {name!r}. Available: {list(MODEL_REGISTRY)}")
+
+    model_cls = MODEL_REGISTRY[name]
+
+    if name == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        return model_cls(api_key=api_key)
+    elif name == "anthropic":
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        return model_cls(api_key=api_key)
+
+    return model_cls()
+
+
+def get_judge_api_key() -> str | None:
+    """Get the API key for the judge model (defaults to OpenAI)."""
+    return os.getenv("OPENAI_API_KEY")

--- a/agentbench/evaluators/__init__.py
+++ b/agentbench/evaluators/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluators for scoring model outputs."""

--- a/agentbench/evaluators/base.py
+++ b/agentbench/evaluators/base.py
@@ -1,0 +1,31 @@
+"""Abstract base class for evaluators."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from agentbench.tasks.base import Task
+
+
+@dataclass
+class EvalResult:
+    """Result of an evaluation."""
+
+    task_id: str
+    score: float
+    comment: str
+
+
+class BaseEvaluator(ABC):
+    """Base class that all evaluators must implement."""
+
+    @abstractmethod
+    def evaluate(self, task: Task, model_output: str) -> EvalResult:
+        """Evaluate a model's output for a given task.
+
+        Args:
+            task: The task that was evaluated.
+            model_output: The model's generated output.
+
+        Returns:
+            An EvalResult with score and comment.
+        """

--- a/agentbench/evaluators/llm_judge.py
+++ b/agentbench/evaluators/llm_judge.py
@@ -1,0 +1,74 @@
+"""LLM-as-Judge evaluator."""
+
+import json
+import re
+
+import openai
+
+from agentbench.tasks.base import Task
+
+from .base import BaseEvaluator, EvalResult
+
+JUDGE_SYSTEM_PROMPT = """\
+You are an expert evaluator. You will be given a task prompt, evaluation criteria, \
+and a model's output. Score the output from 1 to 10 based on how well it meets the criteria.
+
+You MUST respond in the following JSON format and nothing else:
+{"score": <integer 1-10>, "comment": "<brief evaluation in the same language as the task>"}\
+"""
+
+JUDGE_USER_TEMPLATE = """\
+## Task Prompt
+{prompt}
+
+## Evaluation Criteria
+{criteria}
+
+## Model Output
+{output}
+
+Please evaluate the output above. Respond with JSON only.\
+"""
+
+
+class LLMJudge(BaseEvaluator):
+    """Uses an LLM to judge model outputs."""
+
+    def __init__(self, model_id: str = "gpt-4o-mini", api_key: str | None = None):
+        self.model_id = model_id
+        self._client = openai.OpenAI(api_key=api_key)
+
+    def evaluate(self, task: Task, model_output: str) -> EvalResult:
+        user_message = JUDGE_USER_TEMPLATE.format(
+            prompt=task.prompt,
+            criteria=task.criteria,
+            output=model_output,
+        )
+
+        response = self._client.chat.completions.create(
+            model=self.model_id,
+            messages=[
+                {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=0.0,
+        )
+
+        raw = response.choices[0].message.content or ""
+        return self._parse_response(task.id, raw)
+
+    @staticmethod
+    def _parse_response(task_id: str, raw: str) -> EvalResult:
+        """Parse the JSON response from the judge model."""
+        # Try to extract JSON from the response
+        json_match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not json_match:
+            return EvalResult(task_id=task_id, score=0, comment=f"Failed to parse judge response: {raw[:200]}")
+
+        try:
+            data = json.loads(json_match.group())
+            score = max(1, min(10, int(data["score"])))
+            comment = str(data.get("comment", ""))
+            return EvalResult(task_id=task_id, score=score, comment=comment)
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return EvalResult(task_id=task_id, score=0, comment=f"Failed to parse judge response: {raw[:200]}")

--- a/agentbench/models/__init__.py
+++ b/agentbench/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model adapters for different LLM providers."""

--- a/agentbench/models/anthropic_model.py
+++ b/agentbench/models/anthropic_model.py
@@ -1,0 +1,25 @@
+"""Anthropic model adapter."""
+
+import anthropic
+
+from .base import BaseModel
+
+
+class AnthropicModel(BaseModel):
+    """Adapter for Anthropic Claude models."""
+
+    def __init__(self, model_id: str = "claude-sonnet-4-20250514", api_key: str | None = None):
+        super().__init__(model_id)
+        self._client = anthropic.Anthropic(api_key=api_key)
+
+    def generate(self, prompt: str) -> str:
+        response = self._client.messages.create(
+            model=self.model_id,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text
+
+    @property
+    def name(self) -> str:
+        return f"anthropic/{self.model_id}"

--- a/agentbench/models/base.py
+++ b/agentbench/models/base.py
@@ -1,0 +1,26 @@
+"""Abstract base class for model adapters."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseModel(ABC):
+    """Base class that all model adapters must implement."""
+
+    def __init__(self, model_id: str):
+        self.model_id = model_id
+
+    @abstractmethod
+    def generate(self, prompt: str) -> str:
+        """Generate a response for the given prompt.
+
+        Args:
+            prompt: The input prompt to send to the model.
+
+        Returns:
+            The model's text response.
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name for this model adapter."""

--- a/agentbench/models/openai_model.py
+++ b/agentbench/models/openai_model.py
@@ -1,0 +1,25 @@
+"""OpenAI model adapter."""
+
+import openai
+
+from .base import BaseModel
+
+
+class OpenAIModel(BaseModel):
+    """Adapter for OpenAI chat completion models."""
+
+    def __init__(self, model_id: str = "gpt-4o-mini", api_key: str | None = None):
+        super().__init__(model_id)
+        self._client = openai.OpenAI(api_key=api_key)
+
+    def generate(self, prompt: str) -> str:
+        response = self._client.chat.completions.create(
+            model=self.model_id,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+        return response.choices[0].message.content or ""
+
+    @property
+    def name(self) -> str:
+        return f"openai/{self.model_id}"

--- a/agentbench/runner.py
+++ b/agentbench/runner.py
@@ -1,0 +1,82 @@
+"""Evaluation runner — orchestrates the full benchmark pipeline."""
+
+import sys
+
+from agentbench.config import get_judge_api_key, get_model
+from agentbench.evaluators.base import EvalResult
+from agentbench.evaluators.llm_judge import LLMJudge
+from agentbench.models.base import BaseModel
+from agentbench.results.reporter import print_report, save_json
+from agentbench.tasks.base import Task
+from agentbench.tasks.loader import load_tasks
+
+
+def run_benchmark(
+    model_names: list[str],
+    tasks_path: str,
+    output_path: str = "results/output.json",
+    judge_model: str = "gpt-4o-mini",
+) -> dict[str, list[EvalResult]]:
+    """Run the full evaluation pipeline.
+
+    Args:
+        model_names: List of model short names (e.g. ['openai', 'anthropic']).
+        tasks_path: Path to the benchmark JSON file.
+        output_path: Where to save the JSON results.
+        judge_model: Model ID for the LLM judge.
+
+    Returns:
+        Mapping of model name -> list of EvalResult.
+    """
+    # Load tasks
+    tasks = load_tasks(tasks_path)
+    print(f"Loaded {len(tasks)} tasks from {tasks_path}")
+
+    # Initialize judge
+    judge = LLMJudge(model_id=judge_model, api_key=get_judge_api_key())
+
+    # Initialize models
+    models: list[BaseModel] = []
+    for name in model_names:
+        try:
+            models.append(get_model(name))
+        except ValueError as e:
+            print(f"Warning: {e}", file=sys.stderr)
+
+    if not models:
+        print("Error: No valid models specified.", file=sys.stderr)
+        sys.exit(1)
+
+    # Run evaluation
+    all_results: dict[str, list[EvalResult]] = {}
+
+    for model in models:
+        print(f"\n--- Evaluating: {model.name} ---")
+        model_results: list[EvalResult] = []
+
+        for task in tasks:
+            print(f"  Task {task.id}: generating...", end=" ", flush=True)
+            try:
+                output = model.generate(task.prompt)
+            except Exception as e:
+                print(f"ERROR: {e}")
+                model_results.append(EvalResult(task_id=task.id, score=0, comment=f"Generation failed: {e}"))
+                continue
+
+            print("judging...", end=" ", flush=True)
+            try:
+                result = judge.evaluate(task, output)
+            except Exception as e:
+                print(f"ERROR: {e}")
+                result = EvalResult(task_id=task.id, score=0, comment=f"Evaluation failed: {e}")
+
+            model_results.append(result)
+            print(f"score={result.score}")
+
+        all_results[model.name] = model_results
+
+    # Report
+    print_report(all_results)
+    save_json(all_results, output_path)
+
+    return all_results

--- a/agentbench/tasks/__init__.py
+++ b/agentbench/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Task definitions and loaders."""

--- a/agentbench/tasks/base.py
+++ b/agentbench/tasks/base.py
@@ -1,0 +1,14 @@
+"""Task data structures."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Task:
+    """A single evaluation task."""
+
+    id: str
+    domain: str
+    capability: str
+    prompt: str
+    criteria: str

--- a/agentbench/tasks/loader.py
+++ b/agentbench/tasks/loader.py
@@ -1,0 +1,31 @@
+"""Load tasks from JSON files."""
+
+import json
+from pathlib import Path
+
+from .base import Task
+
+
+def load_tasks(path: str | Path) -> list[Task]:
+    """Load tasks from a JSON file.
+
+    Args:
+        path: Path to the JSON file containing task definitions.
+
+    Returns:
+        List of Task objects.
+    """
+    path = Path(path)
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    return [
+        Task(
+            id=item["id"],
+            domain=item["domain"],
+            capability=item["capability"],
+            prompt=item["prompt"],
+            criteria=item["criteria"],
+        )
+        for item in data["tasks"]
+    ]

--- a/benchmarks/text_generation.json
+++ b/benchmarks/text_generation.json
@@ -1,0 +1,48 @@
+{
+  "name": "text_generation",
+  "description": "文本生成能力评测 —— 覆盖代码开发、自媒体、期权投资、个体健康四大领域",
+  "tasks": [
+    {
+      "id": "code-doc-1",
+      "domain": "代码开发",
+      "capability": "文本生成",
+      "prompt": "请为以下 Python 函数编写一份清晰的 API 文档，包括函数说明、参数说明、返回值说明和使用示例：\n\ndef retry(func, max_attempts=3, delay=1.0, backoff=2.0, exceptions=(Exception,)):\n    \"\"\"重试装饰器\"\"\"\n    import time\n    from functools import wraps\n    @wraps(func)\n    def wrapper(*args, **kwargs):\n        current_delay = delay\n        for attempt in range(1, max_attempts + 1):\n            try:\n                return func(*args, **kwargs)\n            except exceptions as e:\n                if attempt == max_attempts:\n                    raise\n                time.sleep(current_delay)\n                current_delay *= backoff\n    return wrapper",
+      "criteria": "1. 函数说明准确描述了重试装饰器的用途和行为\n2. 每个参数都有类型标注和清晰的说明\n3. 返回值说明完整\n4. 使用示例正确且有实际意义\n5. 文档格式规范（使用标准的 docstring 格式）\n6. 语言简洁专业"
+    },
+    {
+      "id": "code-doc-2",
+      "domain": "代码开发",
+      "capability": "文本生成",
+      "prompt": "请写一份简要的技术方案文档：在一个 Flask Web 应用中添加基于 Redis 的接口限流功能（Rate Limiting），需包含：方案概述、核心实现思路、关键代码片段、注意事项。",
+      "criteria": "1. 方案概述清晰说明了限流的目的和方法\n2. 实现思路合理（如令牌桶或滑动窗口算法）\n3. 代码片段可运行且与方案一致\n4. 涵盖了关键注意事项（如分布式场景、Key设计、异常处理）\n5. 文档结构清晰、层次分明"
+    },
+    {
+      "id": "media-post-1",
+      "domain": "自媒体",
+      "capability": "文本生成",
+      "prompt": "请以「AI 正在重塑个人生产力」为主题，撰写一篇适合在微信公众号发布的短文（800字左右）。目标读者是对 AI 工具感兴趣的职场人士。要求：标题吸引人、开头有 hook、论点清晰、结尾有行动号召。",
+      "criteria": "1. 标题具有吸引力和点击欲望\n2. 开头有效吸引读者（数据/故事/问题等 hook）\n3. 论点清晰，有具体的 AI 工具或场景举例\n4. 语言风格适合公众号读者（专业但不晦涩）\n5. 结尾有明确的行动号召\n6. 字数在 700-900 字之间\n7. 段落分明，适合手机阅读"
+    },
+    {
+      "id": "options-report-1",
+      "domain": "期权投资",
+      "capability": "文本生成",
+      "prompt": "假设当前 AAPL 股价为 $185，隐含波动率 25%，30天到期。请撰写一份简要的期权策略分析报告，比较以下两种策略的风险收益：\n1. 买入 $190 看涨期权（Call）\n2. 卖出 $180/$175 看跌价差（Bull Put Spread）\n\n要求包括：策略描述、最大盈亏分析、适用场景、风险提示。",
+      "criteria": "1. 策略描述准确，术语使用正确\n2. 最大盈亏计算逻辑正确\n3. 对比分析有实质内容（不是泛泛而谈）\n4. 适用场景判断合理\n5. 风险提示具体且有针对性\n6. 报告结构清晰专业"
+    },
+    {
+      "id": "health-plan-1",
+      "domain": "个体健康",
+      "capability": "文本生成",
+      "prompt": "用户信息：30岁男性，久坐办公（每天8小时以上），BMI 26（轻度超重），无运动习惯，目标是减脂增肌。请制定一份为期4周的入门级运动计划，包括：每周训练安排、具体动作说明、渐进式强度提升策略、注意事项。",
+      "criteria": "1. 计划适合零基础人群，循序渐进\n2. 每周训练安排合理（频率、时长、休息日）\n3. 动作说明具体清晰，可直接执行\n4. 有明确的渐进式强度提升策略\n5. 注意事项包含安全提醒和常见误区\n6. 计划整体有科学依据"
+    },
+    {
+      "id": "health-diet-1",
+      "domain": "个体健康",
+      "capability": "文本生成",
+      "prompt": "请为一位正在进行力量训练的成年人（体重75kg，目标增肌减脂）撰写一天的饮食方案示例，包括三餐和两次加餐。要求注明每餐的食物、大致分量和宏量营养素分配（蛋白质/碳水/脂肪）。",
+      "criteria": "1. 总热量和宏量营养素分配合理（蛋白质充足，约1.6-2.2g/kg体重）\n2. 食物选择实际可操作\n3. 每餐营养素标注清晰\n4. 加餐安排合理（训练前后营养补充）\n5. 整体方案符合运动营养学基本原则"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentbench"
+version = "0.1.0"
+description = "AI Agent evaluation platform for super-individuals"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=1.0",
+    "anthropic>=0.20",
+    "python-dotenv>=1.0",
+]
+
+[project.scripts]
+agentbench = "run:main"

--- a/run.py
+++ b/run.py
@@ -1,0 +1,47 @@
+"""CLI entry point for AgentBench."""
+
+import argparse
+
+from agentbench.runner import run_benchmark
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AgentBench - AI Agent Evaluation Platform")
+    parser.add_argument(
+        "--models",
+        type=str,
+        default="openai",
+        help="Comma-separated model names (e.g. openai,anthropic)",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="benchmarks/text_generation.json",
+        help="Path to the benchmark JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="results/output.json",
+        help="Path for the output JSON file",
+    )
+    parser.add_argument(
+        "--judge",
+        type=str,
+        default="gpt-4o-mini",
+        help="Model ID for the LLM judge",
+    )
+
+    args = parser.parse_args()
+
+    model_names = [m.strip() for m in args.models.split(",")]
+    run_benchmark(
+        model_names=model_names,
+        tasks_path=args.tasks,
+        output_path=args.output,
+        judge_model=args.judge,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add complete evaluation pipeline: define tasks → call models → auto-score → output results
- Model adapters for **OpenAI** (gpt-4o-mini) and **Anthropic** (claude-sonnet) with unified `BaseModel` interface
- **6 benchmark tasks** across 4 domains: code dev, media, options trading, health
- **LLM-as-Judge** evaluator that scores outputs 1-10 with comments
- Terminal ASCII table report + JSON export
- CLI entry: `python run.py --models openai,anthropic --tasks benchmarks/text_generation.json`

## Test plan
- [ ] `pip install -e .` installs without errors
- [ ] `python run.py --help` shows CLI options
- [ ] `python run.py --models openai` runs full pipeline and outputs scores
- [ ] `results/output.json` is generated with correct structure
- [ ] `python run.py --models openai,anthropic` compares both models

🤖 Generated with [Claude Code](https://claude.com/claude-code)