### PR TITLE
Fix workflow permissions for issue comments

### DIFF
--- a/.github/workflows/runner-env-info.yml
+++ b/.github/workflows/runner-env-info.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   # Job 1: Extract runner label from the issue label
   extract-runner:


### PR DESCRIPTION
## Summary
- Workflow 运行时 `GITHUB_TOKEN` 默认没有 issue 写权限，导致发评论时 403 报错
- 添加 `permissions: issues: write` 修复

## Root cause
`Resource not accessible by integration` — 默认 token 权限不足，无法调用 `issues.createComment` API

## Test plan
- [ ] 合并后，移除 issue #3 的 `run-on:self-hosted` 标签再重新添加
- [ ] Job 1 成功发出"已触发"评论
- [ ] Job 2 在 self-hosted runner 上运行（或等待 runner）

🤖 Generated with [Claude Code](https://claude.com/claude-code)