### PR TITLE
Fix: use interactive mode for Claude agent

### DIFF
--- a/.github/workflows/runner-env-info.yml
+++ b/.github/workflows/runner-env-info.yml
@@ -94,7 +94,7 @@ jobs:
           ${ISSUE_COMMENTS}"
 
           echo "=== Invoking Claude Agent ==="
-          claude -p --dangerously-skip-permissions "$PROMPT"
+          echo "$PROMPT" | claude --dangerously-skip-permissions --verbose
 
       - name: Commit and push changes
         id: commit


### PR DESCRIPTION
## Summary
`claude -p` 是 print 模式，Claude 只输出文字回复但**不会实际修改文件**。上次运行 Claude 说 "README.md 已创建完成" 但实际没有产生任何文件变更。

修改为通过 stdin 管道传入 prompt，让 Claude 以正常交互模式运行，使用 Edit/Write 等工具实际修改代码。

## Root cause
`-p` / `--print` flag = "print response and exit"，跳过所有工具调用。

## Test plan
- [ ] 合并后移除 issue #11 的 `run-on:claude` 标签再重新添加
- [ ] Claude 实际创建/修改文件（git diff 有变更）
- [ ] 自动创建 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)