### PR TITLE
feat: add agent/model name to workflow labels and add CLAUDE.md

### DIFF
--- a/.github/workflows/agent-issue-runner.yml
+++ b/.github/workflows/agent-issue-runner.yml
@@ -61,7 +61,9 @@ jobs:
     runs-on: ${{ needs.setup.outputs.runner_label }}
     timeout-minutes: 30
     outputs:
+      agent_name: ${{ steps.version.outputs.agent_name }}
       agent_version: ${{ steps.version.outputs.agent_version }}
+      model_name: ${{ steps.version.outputs.model_name }}
       model_version: ${{ steps.version.outputs.model_version }}
     steps:
       - name: Checkout repository
@@ -69,14 +71,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get agent and model version
+      - name: Get agent and model info
         id: version
         run: |
+          AGENT_NAME="Claude Code"
           AGENT_VERSION=$(claude --version 2>&1 | head -1)
+          echo "agent_name=${AGENT_NAME}" >> "$GITHUB_OUTPUT"
           echo "agent_version=${AGENT_VERSION:-unknown}" >> "$GITHUB_OUTPUT"
 
-          MODEL_VERSION=$(claude config get model 2>/dev/null || echo "unknown")
-          echo "model_version=${MODEL_VERSION:-unknown}" >> "$GITHUB_OUTPUT"
+          MODEL_ID=$(claude config get model 2>/dev/null || echo "unknown")
+          # Extract model name from ID (e.g., "claude-sonnet-4-5-20250514" -> "Claude Sonnet 4.5")
+          MODEL_NAME=$(echo "$MODEL_ID" | sed -E 's/-[0-9]{8}$//' | sed 's/-/ /g' | sed -E 's/([0-9]+) ([0-9]+)/\1.\2/g' | sed 's/\b\(.\)/\u\1/g')
+          echo "model_name=${MODEL_NAME:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "model_version=${MODEL_ID:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Create feature branch
         run: |
@@ -137,12 +144,14 @@ jobs:
             const agentStatus = '${{ needs.agent.result }}';
             const issueNumber = ${{ needs.setup.outputs.issue_number }};
             const branch = `agent/issue-${issueNumber}`;
+            const agentName = '${{ needs.agent.outputs.agent_name }}' || 'unknown';
             const agentVersion = '${{ needs.agent.outputs.agent_version }}' || 'unknown';
+            const modelName = '${{ needs.agent.outputs.model_name }}' || 'unknown';
             const modelVersion = '${{ needs.agent.outputs.model_version }}' || 'unknown';
 
-            // Create and add version labels to the issue
-            const agentLabel = `agent:${agentVersion}`;
-            const modelLabel = `model:${modelVersion}`;
+            // Create and add version labels to the issue (include name and version)
+            const agentLabel = `agent:${agentName} ${agentVersion}`;
+            const modelLabel = `model:${modelName} (${modelVersion})`;
 
             for (const labelInfo of [
               { name: agentLabel, color: '1d76db' },
@@ -171,8 +180,8 @@ jobs:
               labels: [agentLabel, modelLabel],
             });
 
-            // Build result comment with version info
-            const versionInfo = `Agent: \`${agentVersion}\` | Model: \`${modelVersion}\``;
+            // Build result comment with name and version info
+            const versionInfo = `Agent: \`${agentName} ${agentVersion}\` | Model: \`${modelName} (${modelVersion})\``;
             let body = '';
             if (agentStatus !== 'success') {
               body = `❌ Agent failed.\n\n${versionInfo}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AgentBench is an AI Agent evaluation platform for "super-individuals" (独立开发者、自媒体创作者等). It benchmarks AI models across four domains: code development, social media, options trading, and personal health. The core question it answers: which model + agent framework combination performs best in real scenarios.
+
+## Common Commands
+
+```bash
+# Install (editable/dev mode)
+pip install -e .
+
+# Run evaluation (default: OpenAI model)
+python run.py
+
+# Run with multiple models
+python run.py --models openai,anthropic
+
+# Full options
+python run.py --models openai,anthropic --tasks benchmarks/text_generation.json --output results/output.json --judge gpt-4o-mini
+```
+
+There is no test suite or linter configured yet.
+
+## Architecture
+
+The pipeline flows: **load tasks → initialize models → generate outputs → judge with LLM → report results**.
+
+- `run.py` — CLI entry point, parses args and calls `runner.run_benchmark()`
+- `agentbench/runner.py` — Orchestrates the full pipeline: load → generate → evaluate → report
+- `agentbench/config.py` — `MODEL_REGISTRY` dict maps short names ("openai", "anthropic") to model classes; `get_model()` factory instantiates them with API keys from `.env`
+- `agentbench/models/base.py` — `BaseModel` ABC with `generate(prompt) -> str` and `name` property
+- `agentbench/models/openai_model.py` — OpenAI adapter (gpt-4o-mini, temperature=0.7)
+- `agentbench/models/anthropic_model.py` — Anthropic adapter (claude-sonnet-4-20250514, max_tokens=4096)
+- `agentbench/tasks/base.py` — `Task` dataclass (id, domain, capability, prompt, criteria)
+- `agentbench/tasks/loader.py` — Loads tasks from JSON files
+- `agentbench/evaluators/llm_judge.py` — LLM-as-Judge using OpenAI; scores 1-10, temperature=0.0
+- `agentbench/results/reporter.py` — Terminal table output + JSON export with timestamp
+
+## Adding a New Model
+
+1. Create `agentbench/models/yourmodel.py` extending `BaseModel`
+2. Register it in `MODEL_REGISTRY` in `agentbench/config.py`
+3. Handle API key retrieval in `get_model()` if needed
+
+## Task Format
+
+Benchmark tasks are in `benchmarks/*.json`:
+```json
+{
+  "tasks": [
+    { "id": "domain-task-N", "domain": "...", "capability": "...", "prompt": "...", "criteria": "..." }
+  ]
+}
+```
+
+## Key Conventions
+
+- Python 3.10+ with type hints (`|` union syntax, dataclasses)
+- API keys managed via `.env` file (loaded by `python-dotenv`); never commit `.env`
+- Git commit messages use conventional prefixes: `feat:`, `fix:`, `docs:`
+- Automated workflow: GitHub Issues with `run-on:<runner>` label trigger Claude agent via `.github/workflows/agent-issue-runner.yml`, which creates a branch `agent/issue-N`, commits, pushes, and opens a PR


### PR DESCRIPTION
## Summary
- Workflow 的 agent_version 和 model_version 之前只有版本号，没有名称信息。现在新增 `agent_name`（"Claude Code"）和 `model_name`（从 model ID 解析出可读名称），Label 和评论同时展示名称和版本
- 新增 CLAUDE.md 文件，为 Claude Code 提供项目架构、常用命令和开发规范的指引

## Test plan
- [ ] 验证 workflow 在 self-hosted runner 上能正确输出 agent_name 和 model_name
- [ ] 确认 Issue label 格式正确（如 `agent:Claude Code 1.0.16`、`model:Claude Sonnet 4.5 (claude-sonnet-4-5-20250514)`）
- [ ] 确认 CLAUDE.md 内容准确描述项目架构

🤖 Generated with [Claude Code](https://claude.com/claude-code)