### PR TITLE
fix: remove agent/model version labels from workflow

### DIFF
--- a/.github/workflows/agent-issue-runner.yml
+++ b/.github/workflows/agent-issue-runner.yml
@@ -60,30 +60,11 @@ jobs:
     needs: setup
     runs-on: ${{ needs.setup.outputs.runner_label }}
     timeout-minutes: 30
-    outputs:
-      agent_name: ${{ steps.version.outputs.agent_name }}
-      agent_version: ${{ steps.version.outputs.agent_version }}
-      model_name: ${{ steps.version.outputs.model_name }}
-      model_version: ${{ steps.version.outputs.model_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Get agent and model info
-        id: version
-        run: |
-          AGENT_NAME="Claude Code"
-          AGENT_VERSION=$(claude --version 2>&1 | head -1)
-          echo "agent_name=${AGENT_NAME}" >> "$GITHUB_OUTPUT"
-          echo "agent_version=${AGENT_VERSION:-unknown}" >> "$GITHUB_OUTPUT"
-
-          MODEL_ID=$(claude config get model 2>/dev/null || echo "unknown")
-          # Extract model name from ID (e.g., "claude-sonnet-4-5-20250514" -> "Claude Sonnet 4.5")
-          MODEL_NAME=$(echo "$MODEL_ID" | sed -E 's/-[0-9]{8}$//' | sed 's/-/ /g' | sed -E 's/([0-9]+) ([0-9]+)/\1.\2/g' | sed 's/\b\(.\)/\u\1/g')
-          echo "model_name=${MODEL_NAME:-unknown}" >> "$GITHUB_OUTPUT"
-          echo "model_version=${MODEL_ID:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Create feature branch
         run: |
@@ -131,62 +112,24 @@ jobs:
           claude -p --dangerously-skip-permissions "$PROMPT"
           echo "=== Agent finished ==="
 
-  # Job 3: Notify result on issue and add version labels
+  # Job 3: Notify result on issue
   notify:
     needs: [setup, agent]
     runs-on: ubuntu-latest
     if: always() && needs.setup.result == 'success'
     steps:
-      - name: Post result comment and add version labels
+      - name: Post result comment
         uses: actions/github-script@v7
         with:
           script: |
             const agentStatus = '${{ needs.agent.result }}';
             const issueNumber = ${{ needs.setup.outputs.issue_number }};
             const branch = `agent/issue-${issueNumber}`;
-            const agentName = '${{ needs.agent.outputs.agent_name }}' || 'unknown';
-            const agentVersion = '${{ needs.agent.outputs.agent_version }}' || 'unknown';
-            const modelName = '${{ needs.agent.outputs.model_name }}' || 'unknown';
-            const modelVersion = '${{ needs.agent.outputs.model_version }}' || 'unknown';
 
-            // Create and add version labels to the issue (include name and version)
-            const agentLabel = `agent:${agentName} ${agentVersion}`;
-            const modelLabel = `model:${modelName} (${modelVersion})`;
-
-            for (const labelInfo of [
-              { name: agentLabel, color: '1d76db' },
-              { name: modelLabel, color: '0e8a16' },
-            ]) {
-              try {
-                await github.rest.issues.getLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: labelInfo.name,
-                });
-              } catch {
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: labelInfo.name,
-                  color: labelInfo.color,
-                });
-              }
-            }
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: [agentLabel, modelLabel],
-            });
-
-            // Build result comment with name and version info
-            const versionInfo = `Agent: \`${agentName} ${agentVersion}\` | Model: \`${modelName} (${modelVersion})\``;
             let body = '';
             if (agentStatus !== 'success') {
-              body = `❌ Agent failed.\n\n${versionInfo}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              body = `❌ Agent failed.\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             } else {
-              // Check if PR was created
               const { data: prs } = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -194,9 +137,9 @@ jobs:
                 state: 'open',
               });
               if (prs.length > 0) {
-                body = `✅ Agent completed and created PR: ${prs[0].html_url}\n\n${versionInfo}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                body = `✅ Agent completed and created PR: ${prs[0].html_url}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
               } else {
-                body = `⚠️ Agent completed but no PR was created.\n\n${versionInfo}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                body = `⚠️ Agent completed but no PR was created.\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
               }
             }
 


### PR DESCRIPTION
## Summary
- Remove agent/model name and version detection step from the agent job
- Remove version label creation and attachment logic from the notify job
- Simplify notify job to only post basic result comments (success/failure/no PR)

Fixes the `SyntaxError: Unexpected identifier 'S'` error in the notify job, caused by `claude --version` output containing spaces that broke JavaScript string interpolation in `github-script`.

## Test plan
- [ ] Trigger a workflow run via issue label and verify the notify job completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)