### PR TITLE
Agent: resolve issue #19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,14 @@ AgentBench is an AI Agent evaluation platform for "super-individuals" (独立开
 # Install (editable/dev mode)
 pip install -e .
 
-# Run evaluation (default: OpenAI model)
+# Run evaluation (default: OpenAI model via OpenRouter)
 python run.py
 
 # Run with multiple models
 python run.py --models openai,anthropic
 
-# Full options
-python run.py --models openai,anthropic --tasks benchmarks/text_generation.json --output results/output.json --judge gpt-4o-mini
+# Full options (judge uses OpenRouter model ID format)
+python run.py --models openai,anthropic --tasks benchmarks/text_generation.json --output results/output.json --judge openai/gpt-4o-mini
 ```
 
 There is no test suite or linter configured yet.
@@ -30,13 +30,14 @@ The pipeline flows: **load tasks → initialize models → generate outputs → 
 
 - `run.py` — CLI entry point, parses args and calls `runner.run_benchmark()`
 - `agentbench/runner.py` — Orchestrates the full pipeline: load → generate → evaluate → report
-- `agentbench/config.py` — `MODEL_REGISTRY` dict maps short names ("openai", "anthropic") to model classes; `get_model()` factory instantiates them with API keys from `.env`
+- `agentbench/config.py` — `MODEL_REGISTRY` dict maps short names ("openai", "anthropic") to `OpenRouterModel`; `get_model()` factory instantiates them with `OPENROUTER_API_KEY` from `.env`
 - `agentbench/models/base.py` — `BaseModel` ABC with `generate(prompt) -> str` and `name` property
-- `agentbench/models/openai_model.py` — OpenAI adapter (gpt-4o-mini, temperature=0.7)
-- `agentbench/models/anthropic_model.py` — Anthropic adapter (claude-sonnet-4-20250514, max_tokens=4096)
+- `agentbench/models/openrouter_model.py` — OpenRouter adapter; routes all models through OpenRouter's OpenAI-compatible API
+- `agentbench/models/openai_model.py` — Legacy OpenAI direct adapter (kept for reference)
+- `agentbench/models/anthropic_model.py` — Legacy Anthropic direct adapter (kept for reference)
 - `agentbench/tasks/base.py` — `Task` dataclass (id, domain, capability, prompt, criteria)
 - `agentbench/tasks/loader.py` — Loads tasks from JSON files
-- `agentbench/evaluators/llm_judge.py` — LLM-as-Judge using OpenAI; scores 1-10, temperature=0.0
+- `agentbench/evaluators/llm_judge.py` — LLM-as-Judge via OpenRouter; scores 1-10, temperature=0.0
 - `agentbench/results/reporter.py` — Terminal table output + JSON export with timestamp
 
 ## Adding a New Model
@@ -59,6 +60,6 @@ Benchmark tasks are in `benchmarks/*.json`:
 ## Key Conventions
 
 - Python 3.10+ with type hints (`|` union syntax, dataclasses)
-- API keys managed via `.env` file (loaded by `python-dotenv`); never commit `.env`
+- API keys managed via `.env` file (loaded by `python-dotenv`); uses `OPENROUTER_API_KEY`; never commit `.env`
 - Git commit messages use conventional prefixes: `feat:`, `fix:`, `docs:`
 - Automated workflow: GitHub Issues with `run-on:<runner>` label trigger Claude agent via `.github/workflows/agent-issue-runner.yml`, which creates a branch `agent/issue-N`, commits, pushes, and opens a PR

--- a/agentbench/config.py
+++ b/agentbench/config.py
@@ -4,21 +4,28 @@ import os
 
 from dotenv import load_dotenv
 
-from agentbench.models.anthropic_model import AnthropicModel
 from agentbench.models.base import BaseModel
-from agentbench.models.openai_model import OpenAIModel
+from agentbench.models.openrouter_model import OpenRouterModel
 
 load_dotenv()
 
-# Model registry: short name -> factory function
+# Default model IDs used when routing through OpenRouter
+OPENROUTER_MODEL_IDS: dict[str, str] = {
+    "openai": "openai/gpt-4o-mini",
+    "anthropic": "anthropic/claude-sonnet-4-20250514",
+}
+
+# Model registry: short name -> factory class
 MODEL_REGISTRY: dict[str, type[BaseModel]] = {
-    "openai": OpenAIModel,
-    "anthropic": AnthropicModel,
+    "openai": OpenRouterModel,
+    "anthropic": OpenRouterModel,
 }
 
 
 def get_model(name: str) -> BaseModel:
     """Create a model instance by short name.
+
+    All models are routed through OpenRouter using a single OPENROUTER_API_KEY.
 
     Args:
         name: One of 'openai', 'anthropic'.
@@ -30,18 +37,11 @@ def get_model(name: str) -> BaseModel:
     if name not in MODEL_REGISTRY:
         raise ValueError(f"Unknown model: {name!r}. Available: {list(MODEL_REGISTRY)}")
 
-    model_cls = MODEL_REGISTRY[name]
-
-    if name == "openai":
-        api_key = os.getenv("OPENAI_API_KEY")
-        return model_cls(api_key=api_key)
-    elif name == "anthropic":
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        return model_cls(api_key=api_key)
-
-    return model_cls()
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    model_id = OPENROUTER_MODEL_IDS[name]
+    return OpenRouterModel(model_id=model_id, api_key=api_key)
 
 
 def get_judge_api_key() -> str | None:
-    """Get the API key for the judge model (defaults to OpenAI)."""
-    return os.getenv("OPENAI_API_KEY")
+    """Get the API key for the judge model (OpenRouter)."""
+    return os.getenv("OPENROUTER_API_KEY")

--- a/agentbench/evaluators/llm_judge.py
+++ b/agentbench/evaluators/llm_judge.py
@@ -1,10 +1,11 @@
-"""LLM-as-Judge evaluator."""
+"""LLM-as-Judge evaluator — routes through OpenRouter."""
 
 import json
 import re
 
 import openai
 
+from agentbench.models.openrouter_model import OPENROUTER_BASE_URL
 from agentbench.tasks.base import Task
 
 from .base import BaseEvaluator, EvalResult
@@ -34,9 +35,12 @@ Please evaluate the output above. Respond with JSON only.\
 class LLMJudge(BaseEvaluator):
     """Uses an LLM to judge model outputs."""
 
-    def __init__(self, model_id: str = "gpt-4o-mini", api_key: str | None = None):
+    def __init__(self, model_id: str = "openai/gpt-4o-mini", api_key: str | None = None):
         self.model_id = model_id
-        self._client = openai.OpenAI(api_key=api_key)
+        self._client = openai.OpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=api_key,
+        )
 
     def evaluate(self, task: Task, model_output: str) -> EvalResult:
         user_message = JUDGE_USER_TEMPLATE.format(

--- a/agentbench/models/openrouter_model.py
+++ b/agentbench/models/openrouter_model.py
@@ -1,0 +1,30 @@
+"""OpenRouter model adapter — routes requests through OpenRouter's unified API."""
+
+import openai
+
+from .base import BaseModel
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class OpenRouterModel(BaseModel):
+    """Adapter that accesses any model via OpenRouter's OpenAI-compatible API."""
+
+    def __init__(self, model_id: str, api_key: str | None = None):
+        super().__init__(model_id)
+        self._client = openai.OpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=api_key,
+        )
+
+    def generate(self, prompt: str) -> str:
+        response = self._client.chat.completions.create(
+            model=self.model_id,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+        return response.choices[0].message.content or ""
+
+    @property
+    def name(self) -> str:
+        return f"openrouter/{self.model_id}"

--- a/agentbench/runner.py
+++ b/agentbench/runner.py
@@ -15,7 +15,7 @@ def run_benchmark(
     model_names: list[str],
     tasks_path: str,
     output_path: str = "results/output.json",
-    judge_model: str = "gpt-4o-mini",
+    judge_model: str = "openai/gpt-4o-mini",
 ) -> dict[str, list[EvalResult]]:
     """Run the full evaluation pipeline.
 

--- a/run.py
+++ b/run.py
@@ -28,8 +28,8 @@ def main():
     parser.add_argument(
         "--judge",
         type=str,
-        default="gpt-4o-mini",
-        help="Model ID for the LLM judge",
+        default="openai/gpt-4o-mini",
+        help="Model ID for the LLM judge (OpenRouter format, e.g. openai/gpt-4o-mini)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Replace direct OpenAI and Anthropic API connections with OpenRouter's unified API gateway
- All models (both generation and LLM judge) now route through a single `OPENROUTER_API_KEY`
- Added `agentbench/models/openrouter_model.py` as the new unified model adapter
- Updated `config.py`, `llm_judge.py`, `runner.py`, and `run.py` to use OpenRouter

## Why
Server environments have strict requirements for direct OpenAI/Anthropic connections. OpenRouter provides a single unified endpoint that supports all models, simplifying deployment and API key management.

## Test plan
- [ ] Set `OPENROUTER_API_KEY` in `.env` and run `python run.py --models openai,anthropic`
- [ ] Verify both OpenAI and Anthropic models generate responses via OpenRouter
- [ ] Verify the LLM judge evaluates correctly via OpenRouter

Automated PR by Claude Agent. Resolves #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)