### PR TITLE
feat: update Google model and track model output in eval results

### DIFF
--- a/agentbench/config.py
+++ b/agentbench/config.py
@@ -13,7 +13,7 @@ load_dotenv()
 OPENROUTER_MODEL_IDS: dict[str, str] = {
     "openai": "openai/gpt-5.2",
     "anthropic": "anthropic/claude-sonnet-4.6",
-    "google": "google/gemini-2.5-flash",
+    "google": "google/gemini-3.1-pro-preview",
     "deepseek": "deepseek/deepseek-v3.2",
 }
 

--- a/agentbench/evaluators/base.py
+++ b/agentbench/evaluators/base.py
@@ -13,6 +13,7 @@ class EvalResult:
     task_id: str
     score: float
     comment: str
+    model_output: str = ""
 
 
 class BaseEvaluator(ABC):

--- a/agentbench/runner.py
+++ b/agentbench/runner.py
@@ -66,9 +66,10 @@ def run_benchmark(
             print("judging...", end=" ", flush=True)
             try:
                 result = judge.evaluate(task, output)
+                result.model_output = output
             except Exception as e:
                 print(f"ERROR: {e}")
-                result = EvalResult(task_id=task.id, score=0, comment=f"Evaluation failed: {e}")
+                result = EvalResult(task_id=task.id, score=0, comment=f"Evaluation failed: {e}", model_output=output)
 
             model_results.append(result)
             print(f"score={result.score}")


### PR DESCRIPTION
## Summary
- Update Google model from `gemini-2.5-flash` to `gemini-3.1-pro-preview` for more accurate benchmarking
- Add `model_output` field to `EvalResult` dataclass to preserve raw model responses
- Store model output in evaluation results (both success and failure cases) for debugging and analysis

## Test plan
- [ ] Run `python run.py --models google` to verify the new Google model ID works
- [ ] Verify eval results include `model_output` in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)