### PR TITLE
feat: add comment-trigger workflow for Claude agent

### DIFF
--- a/.github/workflows/agent-comment-runner.yml
+++ b/.github/workflows/agent-comment-runner.yml
@@ -1,0 +1,229 @@
+name: Claude Agent (Comment Trigger)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Job 1: Validate /claude command, check completion status, parse inputs
+  setup:
+    runs-on: ubuntu-latest
+    # Only trigger on issue comments (not PR comments) starting with "/claude "
+    if: >-
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/claude ')
+    outputs:
+      should_run: ${{ steps.guard.outputs.should_run }}
+      issue_number: ${{ steps.parse.outputs.issue_number }}
+      issue_title: ${{ steps.parse.outputs.issue_title }}
+      issue_body: ${{ steps.parse.outputs.issue_body }}
+      comment_id: ${{ steps.parse.outputs.comment_id }}
+      task_prompt: ${{ steps.parse.outputs.task_prompt }}
+    steps:
+      - name: Check if already completed (has rocket reaction)
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: reactions } = await github.rest.reactions.listForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+            });
+            const completed = reactions.some(r => r.content === 'rocket');
+            if (completed) {
+              core.info('Comment already has 🚀 reaction (completed). Skipping.');
+              core.setOutput('should_run', 'false');
+            } else {
+              core.setOutput('should_run', 'true');
+            }
+
+      - name: Add eyes reaction (received)
+        if: steps.guard.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Parse comment and issue info
+        if: steps.guard.outputs.should_run == 'true'
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const taskPrompt = body.replace(/^\/claude\s+/, '').trim();
+            if (!taskPrompt) {
+              core.setFailed('No task specified after /claude');
+              return;
+            }
+            core.setOutput('comment_id', context.payload.comment.id.toString());
+            core.setOutput('issue_number', context.payload.issue.number.toString());
+            core.setOutput('issue_title', context.payload.issue.title);
+            core.setOutput('issue_body', context.payload.issue.body || '(no description)');
+            core.setOutput('task_prompt', taskPrompt);
+
+  # Job 2: Run Claude agent on self-hosted runner
+  agent:
+    needs: setup
+    if: needs.setup.outputs.should_run == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create feature branch
+        run: |
+          git checkout -b "agent/issue-${{ needs.setup.outputs.issue_number }}-${{ needs.setup.outputs.comment_id }}"
+
+      - name: Run claude agent
+        env:
+          ISSUE_NUMBER: ${{ needs.setup.outputs.issue_number }}
+          ISSUE_TITLE: ${{ needs.setup.outputs.issue_title }}
+          ISSUE_BODY: ${{ needs.setup.outputs.issue_body }}
+          TASK_PROMPT: ${{ needs.setup.outputs.task_prompt }}
+        run: |
+          CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
+          echo "=== Claude Code version: ${CLAUDE_VERSION} ==="
+          echo "$CLAUDE_VERSION" > .claude-agent-version
+
+          PROMPT=$(cat <<PROMPTEOF
+          你是一个自动化开发 Agent。请根据以下 GitHub Issue 和评论中的指令完成开发任务。
+
+          ## Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
+          ### Issue 描述
+          ${ISSUE_BODY}
+
+          ### 本次任务指令
+          ${TASK_PROMPT}
+
+          ## 你需要完成的步骤
+
+          1. 阅读项目代码，理解项目结构
+          2. 根据任务指令修改或创建代码文件
+          3. 在项目根目录创建文件 .claude-model-info，内容为你实际使用的模型名称和版本（例如 claude-opus-4-6），只写模型ID，不要写其他内容
+
+          重要：你只需要完成代码的修改或创建以及写入模型信息文件，不需要执行 git 操作或创建 PR，这些由 workflow 自动完成。
+          PROMPTEOF
+          )
+
+          echo "=== Invoking Claude Agent ==="
+          claude -p --dangerously-skip-permissions "$PROMPT"
+          echo "=== Agent finished ==="
+
+      - name: Collect agent info and commit changes
+        env:
+          ISSUE_NUMBER: ${{ needs.setup.outputs.issue_number }}
+          ISSUE_TITLE: ${{ needs.setup.outputs.issue_title }}
+        run: |
+          CLAUDE_VERSION="unknown"
+          if [ -f .claude-agent-version ]; then
+            CLAUDE_VERSION=$(cat .claude-agent-version)
+            rm .claude-agent-version
+          fi
+
+          CLAUDE_MODEL="unknown"
+          if [ -f .claude-model-info ]; then
+            CLAUDE_MODEL=$(cat .claude-model-info)
+            rm .claude-model-info
+          fi
+
+          echo "Agent: Claude Code ${CLAUDE_VERSION}"
+          echo "Model: ${CLAUDE_MODEL}"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
+
+          printf 'feat: resolve issue #%s - %s\n\nAgent: Claude Code %s\nModel: %s\n' \
+            "$ISSUE_NUMBER" "$ISSUE_TITLE" "$CLAUDE_VERSION" "$CLAUDE_MODEL" > /tmp/commit-msg.txt
+          git commit -F /tmp/commit-msg.txt
+
+          echo "$CLAUDE_VERSION" > /tmp/claude-agent-version
+          echo "$CLAUDE_MODEL" > /tmp/claude-model-info
+
+      - name: Push branch
+        run: |
+          git push origin "agent/issue-${{ needs.setup.outputs.issue_number }}-${{ needs.setup.outputs.comment_id }}"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TASK_PROMPT: ${{ needs.setup.outputs.task_prompt }}
+          ISSUE_NUMBER: ${{ needs.setup.outputs.issue_number }}
+          COMMENT_ID: ${{ needs.setup.outputs.comment_id }}
+        run: |
+          CLAUDE_VERSION=$(cat /tmp/claude-agent-version 2>/dev/null || echo "unknown")
+          CLAUDE_MODEL=$(cat /tmp/claude-model-info 2>/dev/null || echo "unknown")
+
+          printf 'Automated PR by Claude Agent. Resolves #%s\n\n**Task:** %s\n**Agent:** Claude Code %s\n**Model:** %s\n' \
+            "$ISSUE_NUMBER" "$TASK_PROMPT" "$CLAUDE_VERSION" "$CLAUDE_MODEL" > /tmp/pr-body.md
+
+          gh pr create \
+            --title "Agent: resolve issue #${ISSUE_NUMBER}" \
+            --base main \
+            --head "agent/issue-${ISSUE_NUMBER}-${COMMENT_ID}" \
+            --body-file /tmp/pr-body.md
+
+  # Job 3: Notify result and mark completion with rocket reaction
+  notify:
+    needs: [setup, agent]
+    runs-on: ubuntu-latest
+    if: always() && needs.setup.result == 'success' && needs.setup.outputs.should_run == 'true'
+    steps:
+      - name: Post result and mark completion
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const agentStatus = '${{ needs.agent.result }}';
+            const issueNumber = ${{ needs.setup.outputs.issue_number }};
+            const commentId = ${{ needs.setup.outputs.comment_id }};
+            const branch = `agent/issue-${issueNumber}-${commentId}`;
+
+            let body = '';
+            if (agentStatus === 'success') {
+              // Mark as completed with rocket reaction (prevents re-processing)
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                content: 'rocket',
+              });
+
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open',
+              });
+              if (prs.length > 0) {
+                body = `✅ Agent completed and created PR: ${prs[0].html_url}\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              } else {
+                body = `⚠️ Agent completed but no PR was created.\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              }
+            } else {
+              body = `❌ Agent failed.\n\nLogs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: body,
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,5 @@ Benchmark tasks are in `benchmarks/*.json`:
 - Python 3.10+ with type hints (`|` union syntax, dataclasses)
 - API keys managed via `.env` file (loaded by `python-dotenv`); uses `OPENROUTER_API_KEY`; never commit `.env`
 - Git commit messages use conventional prefixes: `feat:`, `fix:`, `docs:`
-- Automated workflow: GitHub Issues with `run-on:<runner>` label trigger Claude agent via `.github/workflows/agent-issue-runner.yml`, which creates a branch `agent/issue-N`, commits, pushes, and opens a PR
+- Automated workflow (label trigger): GitHub Issues with `run-on:<runner>` label trigger Claude agent via `.github/workflows/agent-issue-runner.yml`, which creates a branch `agent/issue-N`, commits, pushes, and opens a PR
+- Automated workflow (comment trigger): Issue comment `/claude <task>` triggers Claude agent via `.github/workflows/agent-comment-runner.yml`, which creates a branch `agent/issue-N-<comment_id>`, commits, pushes, and opens a PR. Uses 👀 reaction = received, 🚀 reaction = completed (prevents re-processing)


### PR DESCRIPTION
## Summary
- 新增 `.github/workflows/agent-comment-runner.yml`：通过 Issue 评论 `/claude <task>` 触发 Claude Agent 自动完成开发任务
- 更新 `CLAUDE.md`：补充 comment-trigger workflow 的文档说明

## Workflow 设计
- **setup job**: 校验 `/claude` 命令、👀 标记已接收、🚀 防重复处理
- **agent job** (self-hosted): checkout → 建分支 → 调用 Claude → commit & push → 创建 PR
- **notify job**: 回复 issue 评论通知结果（成功/失败）

## Test plan
- [ ] 在 Issue 中评论 `/claude <task>` 验证触发
- [ ] 验证重复评论不会重复执行（🚀 guard）
- [ ] 验证 PR 创建和 issue 回复通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)